### PR TITLE
Change from PublishTrimmed to PublishAot

### DIFF
--- a/ChatterinoUpdater/ChatterinoUpdater.csproj
+++ b/ChatterinoUpdater/ChatterinoUpdater.csproj
@@ -11,6 +11,6 @@
     <Nullable>enable</Nullable>
     <ApplicationIcon>icon.ico</ApplicationIcon>
     <StartupObject>ChatterinoUpdater.Program</StartupObject>
-	<PublishTrimmed>true</PublishTrimmed>
+	<PublishAot>true</PublishAot>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
When testing it the artifact size was reduced from 11.6MB to 2.39MB (See https://github.com/Wissididom/chatterino-updater-win/pull/3)
I haven't tested it yet, as I did the change on GitHub's UI and there are no code changes.